### PR TITLE
fix: use variables for consistent naming

### DIFF
--- a/modules/compute/README.md
+++ b/modules/compute/README.md
@@ -67,7 +67,7 @@ This module requires:
 1. **Networking Module** - Must be deployed first to provide VPC network and subnets
 2. **IAM Module** - Must be deployed first to provide service account for instances
 
-## Inputs
+## Variables
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|

--- a/modules/networking/README.md
+++ b/modules/networking/README.md
@@ -44,7 +44,7 @@ module "networking" {
 }
 ```
 
-## Input Variables
+## Variables
 
 | Variable | Type | Default | Description |
 |----------|------|---------|-------------|


### PR DESCRIPTION
## Changes

- Uses `variables` for input value title in READMEs
