### PR TITLE
fix: naming so tf reg picks it up

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ This project adheres to the [Contributor Covenant Code of Conduct](CODE_OF_CONDU
 
 ### Reporting Bugs
 
-- Use the [GitHub issue tracker](https://github.com/buildkite/elastic-ci-stack-for-gcp/issues)
+- Use the [GitHub issue tracker](https://github.com/buildkite/terraform-buildkite-elastic-ci-stack-for-gcp/issues)
 - Check if the bug has already been reported
 - Include:
   - Terraform version

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Create a `main.tf` file:
 
 ```hcl
 module "buildkite_stack" {
-  source = "github.com/buildkite/elastic-ci-stack-for-gcp"
+  source = "github.com/buildkite/terraform-buildkite-elastic-ci-stack-for-gcp"
 
   # Required
   project_id                  = "your-gcp-project"


### PR DESCRIPTION
changes the name of the repo in links to match new name
