### PR TITLE
chore: improve regex matching

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -24,7 +24,7 @@
       "customType": "regex",
       "fileMatch": ["^packer/linux/scripts/install-buildkite-agent$"],
       "matchStrings": [
-        "AGENT_VERSION=(?<currentValue>.*?)\\n"
+        "AGENT_VERSION=(?<currentValue>[^\\s]+)"
       ],
       "datasourceTemplate": "github-releases",
       "depNameTemplate": "buildkite/agent",


### PR DESCRIPTION
## Changes

- Doesn't require a `\n` for agent version match, will use any white space
