### PR TITLE
Use opportunistic MIG updates to avoid interrupting running jobs

### DIFF
--- a/.buildkite/build-agent-image.yml
+++ b/.buildkite/build-agent-image.yml
@@ -71,7 +71,9 @@ steps:
     steps:
       - label: ":terraform: Format Check"
         key: terraform-fmt
-        if_changed: "**/*.tf"
+        if_changed:
+          - "**/*.tf"
+          - "**/*.tftest.hcl"
         command: .buildkite/scripts/format_check
         plugins:
           - *terraform_docker
@@ -84,6 +86,19 @@ steps:
           - "**/*.tf"
           - "**/*.tfvars"
         command: .buildkite/scripts/validate
+        plugins:
+          - *terraform_docker
+        agents:
+          queue: "gcp"
+
+      - label: ":terraform: Test Modules"
+        key: terraform-test-modules
+        if_changed:
+          - "**/*.tf"
+          - "**/*.tfvars"
+          - "**/*.tftest.hcl"
+          - ".buildkite/scripts/test_terraform"
+        command: .buildkite/scripts/test_terraform
         plugins:
           - *terraform_docker
         agents:

--- a/.buildkite/build-agent-image.yml
+++ b/.buildkite/build-agent-image.yml
@@ -4,21 +4,25 @@ definitions:
       image: "hashicorp/terraform:1.13"
       workdir: "/workdir"
       entrypoint: "/bin/sh"
+      chown: true
   tflint: &tflint
     docker#v5.14.0:
       image: "ghcr.io/terraform-linters/tflint:v0.59.1"
       workdir: "/workdir"
       entrypoint: "/bin/sh"
+      chown: true
   tfsec: &tfsec
     docker#v5.14.0:
       image: "aquasec/tfsec:v1.28"
       workdir: "/workdir"
       entrypoint: "/bin/sh"
+      chown: true
   packer: &packer
     docker#v5.14.0:
       image: "hashicorp/packer:1.11"
       workdir: "/workdir"
       entrypoint: "/bin/sh"
+      chown: true
   shellcheck: &shellcheck
     shellcheck#v1.4.0:
       files:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -35,7 +35,10 @@ steps:
     steps:
       - label: ":terraform: Format Check"
         key: terraform-fmt
-        if_changed: "*.tf"
+        if_changed:
+          - "*.tf"
+          - "**/*.tf"
+          - "**/*.tftest.hcl"
         command: .buildkite/scripts/format_check
         plugins:
           - *terraform_docker
@@ -45,20 +48,40 @@ steps:
         if_changed:
           - "*.tf"
           - "*.tfvars"
+          - "**/*.tf"
+          - "**/*.tfvars"
         command: .buildkite/scripts/validate
+        plugins:
+          - *terraform_docker
+
+      - label: ":terraform: Test Modules"
+        key: terraform-test-modules
+        if_changed:
+          - "*.tf"
+          - "*.tfvars"
+          - "*.tftest.hcl"
+          - "**/*.tf"
+          - "**/*.tfvars"
+          - "**/*.tftest.hcl"
+          - ".buildkite/scripts/test_terraform"
+        command: .buildkite/scripts/test_terraform
         plugins:
           - *terraform_docker
 
       - label: ":lint-roller: TFLint"
         key: tflint
-        if_changed: "*.tf"
+        if_changed:
+          - "*.tf"
+          - "**/*.tf"
         command: .buildkite/scripts/tflint
         plugins:
           - *tflint
 
       - label: ":shield: TFSec Security Scan"
         key: tfsec
-        if_changed: "*.tf"
+        if_changed:
+          - "*.tf"
+          - "**/*.tf"
         command: .buildkite/scripts/tfsec
         plugins:
           - *tfsec
@@ -95,6 +118,8 @@ steps:
 
       - label: ":markdown: Markdown Lint"
         key: markdownlint
-        if_changed: "*.md"
+        if_changed:
+          - "*.md"
+          - "**/*.md"
         plugins:
           - *markdownlint

--- a/.buildkite/scripts/test_terraform
+++ b/.buildkite/scripts/test_terraform
@@ -1,0 +1,26 @@
+#!/bin/sh
+set -eu
+
+echo "Running Terraform tests..."
+
+test_files=$(find . -type f -name '*.tftest.hcl' -not -path '*/.terraform/*' -print)
+if [ -z "${test_files}" ]; then
+  echo "No Terraform test files found" >&2
+  exit 1
+fi
+
+mapped_dirs=$(
+  printf '%s\n' "${test_files}" \
+    | sed -e 's|/tests/[^/]*$||' -e 's|/[^/]*\.tftest\.hcl$||'
+)
+module_dirs=$(printf '%s\n' "${mapped_dirs}" | sort -u)
+
+while IFS= read -r module_dir; do
+  echo "Testing ${module_dir}..."
+  terraform -chdir="${module_dir}" init -backend=false -input=false </dev/null
+  terraform -chdir="${module_dir}" test </dev/null
+done <<EOF
+${module_dirs}
+EOF
+
+echo "✅ Terraform tests passed"

--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@ Terraform modules for running autoscaling [Buildkite](https://buildkite.com/) ag
 
 Full documentation is available at <https://buildkite.com/docs/agent/v3/gcp/elastic-ci-stack/elastic-ci-stack>.
 
+Repository documentation:
+
+- [Agent instance updates](docs/instance-updates.md) — includes the changed
+  template-rollout behavior and options for immediate updates
+- [GCP image release pipeline](docs/image-release-pipeline.md)
+
 ## Getting Started
 
 The module ships with a set of default values which can be overridden as needed, but should be sufficient for most use cases.

--- a/docs/instance-updates.md
+++ b/docs/instance-updates.md
@@ -18,17 +18,24 @@ reach existing agents immediately, explicitly update instances only after they
 are idle; otherwise allow normal instance recycling to adopt it without
 interrupting jobs.
 
-The `max_surge` and `max_unavailable` settings apply when an operator explicitly
-starts a rolling update, for example with `gcloud compute instance-groups
-managed rolling-action start-update`. That command changes the live MIG update
-policy and creates temporary Terraform drift, so do not run `terraform apply`
-until the rolling update has finished. The next apply restores the configured
-opportunistic policy.
+The `max_surge` and `max_unavailable` settings do not cause an opportunistic
+template update to roll out automatically. To preserve these limits when
+explicitly starting a rolling update with `gcloud compute instance-groups
+managed rolling-action start-update`, pass both values explicitly with
+`--max-surge` and `--max-unavailable`. If omitted for this stack's stateless
+regional MIG, gcloud defaults both values to the number of zones rather than
+reusing the Terraform settings. For a stateful MIG, omitted `--max-surge`
+instead defaults to `0`; omitted `--max-unavailable` still defaults to the
+number of zones.
 
-These settings do not cause an opportunistic template update to roll out
-automatically, and they do not limit a selective `update-instances` request
-targeting named VMs. Prefer `update-instances` when you have identified specific
-idle agents to recycle.
+Starting a rolling update changes the live MIG update policy and creates
+temporary Terraform drift, so do not run `terraform apply` until the rolling
+update has finished. The next apply restores the configured opportunistic
+policy.
+
+These settings do not limit a selective `update-instances` request targeting
+named VMs. Prefer `update-instances` when you have identified specific idle
+agents to recycle.
 
 Disabling proactive redistribution can temporarily leave instances unevenly
 distributed between zones after instance removal. The regional group still

--- a/docs/instance-updates.md
+++ b/docs/instance-updates.md
@@ -1,0 +1,36 @@
+# Agent instance updates
+
+The regional managed instance group uses an opportunistic update policy. When
+the instance template changes, Google Cloud records the new target template but
+does not proactively replace existing agent VMs. Proactive instance
+redistribution is also disabled so that the group does not delete a running
+agent merely to rebalance instances between zones.
+
+New instances use the latest template when the group scales out or otherwise
+creates a replacement. Existing instances therefore adopt template changes as
+they are recycled, rather than through an immediate rolling update. This avoids
+interrupting jobs, but means a template change can take time to reach the whole
+fleet when demand and instance membership remain stable.
+
+This is a change from earlier stack releases, where instance template changes
+triggered an immediate proactive rollout. If a security-sensitive change must
+reach existing agents immediately, explicitly update instances only after they
+are idle; otherwise allow normal instance recycling to adopt it without
+interrupting jobs.
+
+The `max_surge` and `max_unavailable` settings apply when an operator explicitly
+starts a rolling update, for example with `gcloud compute instance-groups
+managed rolling-action start-update`. That command changes the live MIG update
+policy and creates temporary Terraform drift, so do not run `terraform apply`
+until the rolling update has finished. The next apply restores the configured
+opportunistic policy.
+
+These settings do not cause an opportunistic template update to roll out
+automatically, and they do not limit a selective `update-instances` request
+targeting named VMs. Prefer `update-instances` when you have identified specific
+idle agents to recycle.
+
+Disabling proactive redistribution can temporarily leave instances unevenly
+distributed between zones after instance removal. The regional group still
+converges toward balance when later resize operations create or remove
+instances.

--- a/modules/compute/main.tf
+++ b/modules/compute/main.tf
@@ -87,9 +87,12 @@ resource "google_compute_region_instance_group_manager" "buildkite_agents" {
 
   distribution_policy_zones = var.zones
 
+  # Apply new instance templates only when the MIG creates or otherwise
+  # replaces an instance. Proactive updates and redistribution could select an
+  # agent that is still running a job.
   update_policy {
-    type                         = "PROACTIVE"
-    instance_redistribution_type = "PROACTIVE"
+    type                         = "OPPORTUNISTIC"
+    instance_redistribution_type = "NONE"
     minimal_action               = "REPLACE"
     max_surge_fixed              = var.max_surge
     max_unavailable_fixed        = var.max_unavailable

--- a/modules/compute/tests/update_policy.tftest.hcl
+++ b/modules/compute/tests/update_policy.tftest.hcl
@@ -1,0 +1,49 @@
+mock_provider "google" {}
+
+run "uses_non_disruptive_update_policy" {
+  command = plan
+
+  variables {
+    project_id                  = "test-project"
+    network_self_link           = "projects/test-project/global/networks/test-network"
+    subnet_self_link            = "projects/test-project/regions/us-central1/subnetworks/test-subnet"
+    agent_service_account_email = "agent@test-project.iam.gserviceaccount.com"
+    image                       = "projects/test-project/global/images/test-image"
+    buildkite_organization_slug = "test-organization"
+    buildkite_agent_token       = "test-token"
+    enable_autoscaling          = false
+    enable_autohealing          = false
+    max_surge                   = 5
+    max_unavailable             = 1
+  }
+
+  assert {
+    condition     = google_compute_region_instance_group_manager.buildkite_agents.update_policy[0].type == "OPPORTUNISTIC"
+    error_message = "The managed instance group must not proactively replace agents when its instance template changes."
+  }
+
+  assert {
+    condition     = google_compute_region_instance_group_manager.buildkite_agents.update_policy[0].instance_redistribution_type == "NONE"
+    error_message = "The regional managed instance group must not proactively redistribute agents between zones."
+  }
+
+  assert {
+    condition     = google_compute_region_instance_group_manager.buildkite_agents.update_policy[0].minimal_action == "REPLACE"
+    error_message = "New instance templates must be applied when agents are replaced opportunistically."
+  }
+
+  assert {
+    condition     = google_compute_region_instance_group_manager.buildkite_agents.update_policy[0].replacement_method == "SUBSTITUTE"
+    error_message = "Explicit rolling updates must create replacement agents before removing existing agents."
+  }
+
+  assert {
+    condition     = google_compute_region_instance_group_manager.buildkite_agents.update_policy[0].max_surge_fixed == 5
+    error_message = "Explicit rolling updates must retain the configured surge capacity."
+  }
+
+  assert {
+    condition     = google_compute_region_instance_group_manager.buildkite_agents.update_policy[0].max_unavailable_fixed == 1
+    error_message = "Explicit rolling updates must not make existing agents unavailable before their replacements are ready."
+  }
+}

--- a/modules/compute/tests/update_policy.tftest.hcl
+++ b/modules/compute/tests/update_policy.tftest.hcl
@@ -39,11 +39,11 @@ run "uses_non_disruptive_update_policy" {
 
   assert {
     condition     = google_compute_region_instance_group_manager.buildkite_agents.update_policy[0].max_surge_fixed == 5
-    error_message = "Explicit rolling updates must retain the configured surge capacity."
+    error_message = "The managed instance group update policy must store the configured maximum surge capacity."
   }
 
   assert {
     condition     = google_compute_region_instance_group_manager.buildkite_agents.update_policy[0].max_unavailable_fixed == 1
-    error_message = "Explicit rolling updates must not make existing agents unavailable before their replacements are ready."
+    error_message = "The managed instance group update policy must store the configured maximum unavailable capacity."
   }
 }

--- a/modules/compute/variables.tf
+++ b/modules/compute/variables.tf
@@ -254,7 +254,7 @@ variable "health_check_initial_delay_sec" {
 }
 
 variable "max_surge" {
-  description = "Maximum number of instances that can be created above the target size during an explicitly started rolling update. Instance template changes are not rolled out proactively."
+  description = "Maximum number of instances stored in the MIG update policy above target size. Pass this value explicitly with --max-surge when starting a gcloud rolling update; template changes are not rolled out proactively."
   type        = number
   default     = 3
 
@@ -265,7 +265,7 @@ variable "max_surge" {
 }
 
 variable "max_unavailable" {
-  description = "Maximum number of instances that can be unavailable during an explicitly started rolling update. Instance template changes are not rolled out proactively."
+  description = "Maximum number of unavailable instances stored in the MIG update policy. Pass this value explicitly with --max-unavailable when starting a gcloud rolling update; template changes are not rolled out proactively."
   type        = number
   default     = 0
 

--- a/modules/compute/variables.tf
+++ b/modules/compute/variables.tf
@@ -254,7 +254,7 @@ variable "health_check_initial_delay_sec" {
 }
 
 variable "max_surge" {
-  description = "Maximum number of instances that can be created above the target size during updates"
+  description = "Maximum number of instances that can be created above the target size during an explicitly started rolling update. Instance template changes are not rolled out proactively."
   type        = number
   default     = 3
 
@@ -265,7 +265,7 @@ variable "max_surge" {
 }
 
 variable "max_unavailable" {
-  description = "Maximum number of instances that can be unavailable during updates"
+  description = "Maximum number of instances that can be unavailable during an explicitly started rolling update. Instance template changes are not rolled out proactively."
   type        = number
   default     = 0
 

--- a/variables.tf
+++ b/variables.tf
@@ -378,7 +378,7 @@ variable "health_check_initial_delay_sec" {
 # Update Policy Configuration
 
 variable "max_surge" {
-  description = "Maximum number of instances that can be created above target size during an explicitly started rolling update. Instance template changes are not rolled out proactively."
+  description = "Maximum number of instances stored in the MIG update policy above target size. Pass this value explicitly with --max-surge when starting a gcloud rolling update; template changes are not rolled out proactively."
   type        = number
   default     = 3
 
@@ -389,7 +389,7 @@ variable "max_surge" {
 }
 
 variable "max_unavailable" {
-  description = "Maximum number of instances that can be unavailable during an explicitly started rolling update. Instance template changes are not rolled out proactively."
+  description = "Maximum number of unavailable instances stored in the MIG update policy. Pass this value explicitly with --max-unavailable when starting a gcloud rolling update; template changes are not rolled out proactively."
   type        = number
   default     = 0
 

--- a/variables.tf
+++ b/variables.tf
@@ -378,7 +378,7 @@ variable "health_check_initial_delay_sec" {
 # Update Policy Configuration
 
 variable "max_surge" {
-  description = "Maximum number of instances that can be created above target size during rolling updates"
+  description = "Maximum number of instances that can be created above target size during an explicitly started rolling update. Instance template changes are not rolled out proactively."
   type        = number
   default     = 3
 
@@ -389,7 +389,7 @@ variable "max_surge" {
 }
 
 variable "max_unavailable" {
-  description = "Maximum number of instances that can be unavailable during rolling updates"
+  description = "Maximum number of instances that can be unavailable during an explicitly started rolling update. Instance template changes are not rolled out proactively."
   type        = number
   default     = 0
 


### PR DESCRIPTION
Previously, the managed instance group used a proactive update policy. Changes to the instance template, or proactive redistribution between zones, could cause GCP to replace an agent VM while it was still running a job.

This PR changes the MIG to use an opportunistic update policy and disables proactive instance redistribution. GCP will no longer proactively replace existing agents when the instance template changes or to rebalance the group between zones.

New instances will use the latest template when the group scales out or otherwise creates a replacement. Existing agents will adopt template changes as they are recycled.

The existing `max_surge` and `max_unavailable` settings remain available for rolling updates started explicitly by an operator.

In addition, this PR:

- Adds a Terraform test covering the complete MIG update policy.
- Adds a dedicated Terraform test step to CI.
- Extends CI path matching to cover Terraform modules, Terraform tests, and nested documentation.
- Documents the changed rollout behavior, including options for explicitly updating idle agents and the temporary Terraform drift created by a manually started rolling update.

This is the first part of SUP-7630. Later work will add exact-instance self-removal and then enable agent-controlled, job-safe scale-in.

Context: SUP-7630