### PR TITLE
Implement exact-instance removal from managed instance groups

### DIFF
--- a/.buildkite/build-agent-image.yml
+++ b/.buildkite/build-agent-image.yml
@@ -160,6 +160,12 @@ steps:
         agents:
           queue: "gcp"
 
+      - label: ":bash: Termination Script Tests"
+        key: termination-script-tests
+        command: bash tests/terminate-instance-test
+        agents:
+          queue: "gcp"
+
   - group: ":terraform: Examples"
     key: terraform-example-checks
     steps:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -29,8 +29,6 @@ definitions:
       files:
         - ".buildkite/scripts/*"
         - "packer/linux/scripts/*.sh"
-        - "packer/linux/conf/buildkite-agent/scripts/*"
-        - "tests/*"
 
 steps:
   - group: ":terraform: Root Modules"
@@ -108,18 +106,6 @@ steps:
         key: shellcheck
         plugins:
           - *shellcheck
-
-      - label: ":bash: Lifecycle Script Tests"
-        key: lifecycle-script-tests
-        command: bash tests/stop-agent-gracefully-test
-        agents:
-          queue: "gcp"
-
-      - label: ":bash: Termination Script Tests"
-        key: termination-script-tests
-        command: bash tests/terminate-instance-test
-        agents:
-          queue: "gcp"
 
   - group: "📖 Docs and Examples"
     steps:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -29,6 +29,8 @@ definitions:
       files:
         - ".buildkite/scripts/*"
         - "packer/linux/scripts/*.sh"
+        - "packer/linux/conf/buildkite-agent/scripts/*"
+        - "tests/*"
 
 steps:
   - group: ":terraform: Root Modules"
@@ -106,6 +108,18 @@ steps:
         key: shellcheck
         plugins:
           - *shellcheck
+
+      - label: ":bash: Lifecycle Script Tests"
+        key: lifecycle-script-tests
+        command: bash tests/stop-agent-gracefully-test
+        agents:
+          queue: "gcp"
+
+      - label: ":bash: Termination Script Tests"
+        key: termination-script-tests
+        command: bash tests/terminate-instance-test
+        agents:
+          queue: "gcp"
 
   - group: "📖 Docs and Examples"
     steps:

--- a/packer/linux/conf/buildkite-agent/scripts/terminate-instance
+++ b/packer/linux/conf/buildkite-agent/scripts/terminate-instance
@@ -1,37 +1,144 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Terminate GCP instance gracefully
-echo "--- Terminating GCP instance"
+# This image-baked primitive is intentionally dormant. Before wiring it into an
+# agent lifecycle, the caller must stop the agent and grant the VM permission to
+# update its managed instance group.
+readonly METADATA_URL="${GCP_METADATA_URL:-http://metadata.google.internal/computeMetadata/v1}"
+readonly MAX_ATTEMPTS="${BUILDKITE_TERMINATION_MAX_ATTEMPTS:-4}"
+readonly RETRY_BASE_SECONDS="${BUILDKITE_TERMINATION_RETRY_BASE_SECONDS:-2}"
+readonly GCLOUD_TIMEOUT_SECONDS="${BUILDKITE_TERMINATION_GCLOUD_TIMEOUT_SECONDS:-30}"
 
-# First, stop the Buildkite agent gracefully. The shutdown helper is also used
-# by GCP as a root-run shutdown script and requires root for its systemd and
-# lock-file operations.
-sudo /usr/local/bin/stop-agent-gracefully
+metadata_value() {
+  local path="$1"
 
-# Get instance information
-PROJECT_ID=$(gcp-metadata project-id 2>/dev/null || echo "unknown")
-ZONE=$(gcp-metadata zone 2>/dev/null || echo "unknown")
-INSTANCE_NAME=$(gcp-metadata instance-name 2>/dev/null || echo "unknown")
+  curl --fail --silent --show-error \
+    --connect-timeout 1 \
+    --max-time 2 \
+    --header "Metadata-Flavor: Google" \
+    "${METADATA_URL}/${path}"
+}
 
-echo "Instance details:"
-echo "  Project: $PROJECT_ID"
-echo "  Zone: $ZONE"
-echo "  Instance: $INSTANCE_NAME"
+validate_configuration() {
+  if ! [[ "${MAX_ATTEMPTS}" =~ ^[1-9][0-9]*$ ]]; then
+    echo "BUILDKITE_TERMINATION_MAX_ATTEMPTS must be a positive integer" >&2
+    return 1
+  fi
+  if ! [[ "${RETRY_BASE_SECONDS}" =~ ^[0-9]+$ ]]; then
+    echo "BUILDKITE_TERMINATION_RETRY_BASE_SECONDS must be a non-negative integer" >&2
+    return 1
+  fi
+  if ! [[ "${GCLOUD_TIMEOUT_SECONDS}" =~ ^[1-9][0-9]*$ ]]; then
+    echo "BUILDKITE_TERMINATION_GCLOUD_TIMEOUT_SECONDS must be a positive integer" >&2
+    return 1
+  fi
+}
 
-# Log the termination request
-logger "Buildkite agent requesting instance termination: $INSTANCE_NAME"
+read_instance_identity() {
+  local attempt delay
 
-# We'll need to determine the appropriate method for terminating the instance
-# For now, we'll just prepare the system for shutdown
-echo "Preparing system for termination..."
+  for ((attempt = 1; attempt <= MAX_ATTEMPTS; attempt++)); do
+    if project_id="$(metadata_value project/project-id)" &&
+      instance_name="$(metadata_value instance/name)" &&
+      created_by="$(metadata_value instance/attributes/created-by)"; then
+      return 0
+    fi
 
-# Clean up any remaining processes
-sudo pkill -f buildkite-agent || true
+    if ((attempt < MAX_ATTEMPTS)); then
+      delay=$((RETRY_BASE_SECONDS * (2 ** (attempt - 1))))
+      echo "Unable to read instance metadata (attempt ${attempt}/${MAX_ATTEMPTS}); retrying in ${delay}s" >&2
+      sleep "${delay}"
+    fi
+  done
 
-# Sync filesystem
-sync
+  echo "Unable to read instance identity after ${MAX_ATTEMPTS} attempts" >&2
+  return 1
+}
 
-echo "Instance ready for termination"
-echo "Note: Actual GCP instance termination should be handled by external tooling"
-echo "      with proper authentication and permissions."
+parse_regional_mig() {
+  local manager_path="$1"
+
+  if [[ "${manager_path}" =~ ^projects/[^/]+/regions/([^/]+)/instanceGroupManagers/([^/]+)$ ]]; then
+    region="${BASH_REMATCH[1]}"
+    instance_group_manager="${BASH_REMATCH[2]}"
+    return 0
+  fi
+
+  echo "Instance created-by metadata does not identify a regional managed instance group: ${manager_path}" >&2
+  return 1
+}
+
+delete_exact_instance() {
+  local status
+
+  if ! status="$(
+    timeout --kill-after=5s "${GCLOUD_TIMEOUT_SECONDS}s" \
+      gcloud compute instance-groups managed delete-instances "${instance_group_manager}" \
+      --project="${project_id}" \
+      --region="${region}" \
+      --instances="${instance_name}" \
+      --skip-instances-on-validation-error \
+      --quiet \
+      --format='value(status)'
+  )"; then
+    return 1
+  fi
+
+  status="${status//$'\r'/}"
+  case "${status}" in
+  SUCCESS)
+    echo "GCP accepted deletion of ${instance_name} from ${instance_group_manager}"
+    return 0
+    ;;
+  "")
+    echo "GCP returned no deletion status for ${instance_name}" >&2
+    return 1
+    ;;
+  SKIPPED | MEMBER_NOT_FOUND)
+    echo "Instance ${instance_name} is already absent or being removed from ${instance_group_manager} (${status})"
+    return 0
+    ;;
+  *)
+    echo "GCP did not delete ${instance_name} from ${instance_group_manager} (status: ${status:-missing})" >&2
+    return 1
+    ;;
+  esac
+}
+
+request_termination() {
+  local attempt delay
+
+  for ((attempt = 1; attempt <= MAX_ATTEMPTS; attempt++)); do
+    if delete_exact_instance; then
+      return 0
+    fi
+
+    if ((attempt < MAX_ATTEMPTS)); then
+      delay=$((RETRY_BASE_SECONDS * (2 ** (attempt - 1))))
+      echo "Unable to delete instance (attempt ${attempt}/${MAX_ATTEMPTS}); retrying in ${delay}s" >&2
+      sleep "${delay}"
+    fi
+  done
+
+  echo "Unable to delete instance after ${MAX_ATTEMPTS} attempts" >&2
+  return 1
+}
+
+main() {
+  echo "--- Requesting exact GCP managed instance group removal"
+
+  validate_configuration
+  read_instance_identity
+  parse_regional_mig "${created_by}"
+
+  echo "Instance details:"
+  echo "  Project: ${project_id}"
+  echo "  Region: ${region}"
+  echo "  Managed instance group: ${instance_group_manager}"
+  echo "  Instance: ${instance_name}"
+  logger --tag buildkite-agent "Requesting removal of ${instance_name} from regional managed instance group ${instance_group_manager}"
+
+  request_termination
+}
+
+main "$@"

--- a/tests/terminate-instance-test
+++ b/tests/terminate-instance-test
@@ -1,0 +1,217 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+readonly REPO_ROOT
+readonly SCRIPT="${REPO_ROOT}/packer/linux/conf/buildkite-agent/scripts/terminate-instance"
+TEST_ROOT="$(mktemp -d)"
+readonly TEST_ROOT
+readonly FAKE_BIN="${TEST_ROOT}/bin"
+
+cleanup() {
+  rm -rf "${TEST_ROOT}"
+}
+trap cleanup EXIT
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+assert_contains() {
+  local file="$1"
+  local expected="$2"
+
+  grep -Fq -- "${expected}" "${file}" || fail "${file} does not contain: ${expected}"
+}
+
+assert_not_contains() {
+  local file="$1"
+  local unexpected="$2"
+
+  if grep -Fq -- "${unexpected}" "${file}"; then
+    fail "${file} unexpectedly contains: ${unexpected}"
+  fi
+}
+
+assert_line_count() {
+  local file="$1"
+  local expected="$2"
+  local actual
+
+  actual="$(wc -l <"${file}" | tr -d ' ')"
+  [[ "${actual}" == "${expected}" ]] || fail "${file} contains ${actual} lines, expected ${expected}"
+}
+
+mkdir -p "${FAKE_BIN}"
+
+cat >"${FAKE_BIN}/curl" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >>"${CURL_CALLS_FILE}"
+
+count=0
+if [[ -f "${CURL_COUNT_FILE}" ]]; then
+  read -r count <"${CURL_COUNT_FILE}"
+fi
+count=$((count + 1))
+printf '%s\n' "${count}" >"${CURL_COUNT_FILE}"
+
+if (( count <= ${METADATA_FAILURE_CALLS:-0} )); then
+  exit 22
+fi
+
+case "${*: -1}" in
+  */project/project-id) printf '%s' "${METADATA_PROJECT_ID:-test-project}" ;;
+  */instance/name) printf '%s' "${METADATA_INSTANCE_NAME:-test-agent-abcd}" ;;
+  */instance/attributes/created-by)
+    printf '%s' "${METADATA_CREATED_BY:-projects/123456789/regions/us-central1/instanceGroupManagers/test-mig}"
+    ;;
+  *) exit 22 ;;
+esac
+EOF
+
+cat >"${FAKE_BIN}/gcloud" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >>"${GCLOUD_CALLS_FILE}"
+
+count=0
+if [[ -f "${GCLOUD_COUNT_FILE}" ]]; then
+  read -r count <"${GCLOUD_COUNT_FILE}"
+fi
+count=$((count + 1))
+printf '%s\n' "${count}" >"${GCLOUD_COUNT_FILE}"
+
+IFS=',' read -r -a statuses <<<"${GCLOUD_STATUSES:-SUCCESS}"
+IFS=',' read -r -a exit_codes <<<"${GCLOUD_EXIT_CODES:-0}"
+index=$((count - 1))
+if (( index >= ${#statuses[@]} )); then
+  index=$((${#statuses[@]} - 1))
+fi
+exit_index=$((count - 1))
+if (( exit_index >= ${#exit_codes[@]} )); then
+  exit_index=$((${#exit_codes[@]} - 1))
+fi
+
+if [[ "${GCLOUD_EMPTY_STATUS:-false}" != "true" ]]; then
+  printf '%s\n' "${statuses[${index}]}"
+fi
+exit "${exit_codes[${exit_index}]}"
+EOF
+
+cat >"${FAKE_BIN}/timeout" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >>"${TIMEOUT_CALLS_FILE}"
+shift 2
+exec "$@"
+EOF
+
+cat >"${FAKE_BIN}/sleep" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >>"${SLEEP_CALLS_FILE}"
+EOF
+
+cat >"${FAKE_BIN}/logger" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >>"${LOGGER_CALLS_FILE}"
+EOF
+
+chmod +x "${FAKE_BIN}"/*
+
+run_case() {
+  local name="$1"
+  local expected_exit="${2:-0}"
+  local case_dir="${TEST_ROOT}/${name}"
+  local actual_exit
+
+  mkdir -p "${case_dir}"
+  : >"${case_dir}/curl-calls"
+  : >"${case_dir}/gcloud-calls"
+  : >"${case_dir}/timeout-calls"
+  : >"${case_dir}/sleep-calls"
+  : >"${case_dir}/logger-calls"
+
+  set +e
+  PATH="${FAKE_BIN}:${PATH}" \
+    CURL_CALLS_FILE="${case_dir}/curl-calls" \
+    CURL_COUNT_FILE="${case_dir}/curl-count" \
+    GCLOUD_CALLS_FILE="${case_dir}/gcloud-calls" \
+    GCLOUD_COUNT_FILE="${case_dir}/gcloud-count" \
+    TIMEOUT_CALLS_FILE="${case_dir}/timeout-calls" \
+    SLEEP_CALLS_FILE="${case_dir}/sleep-calls" \
+    LOGGER_CALLS_FILE="${case_dir}/logger-calls" \
+    BUILDKITE_TERMINATION_MAX_ATTEMPTS="${MAX_ATTEMPTS:-4}" \
+    BUILDKITE_TERMINATION_RETRY_BASE_SECONDS=2 \
+    BUILDKITE_TERMINATION_GCLOUD_TIMEOUT_SECONDS=30 \
+    METADATA_FAILURE_CALLS="${METADATA_FAILURE_CALLS:-0}" \
+    METADATA_PROJECT_ID="${METADATA_PROJECT_ID:-test-project}" \
+    METADATA_INSTANCE_NAME="${METADATA_INSTANCE_NAME:-test-agent-abcd}" \
+    METADATA_CREATED_BY="${METADATA_CREATED_BY:-projects/123456789/regions/us-central1/instanceGroupManagers/test-mig}" \
+    GCLOUD_STATUSES="${GCLOUD_STATUSES:-SUCCESS}" \
+    GCLOUD_EXIT_CODES="${GCLOUD_EXIT_CODES:-0}" \
+    GCLOUD_EMPTY_STATUS="${GCLOUD_EMPTY_STATUS:-false}" \
+    bash "${SCRIPT}" >"${case_dir}/output" 2>&1
+  actual_exit=$?
+  set -e
+
+  [[ "${actual_exit}" == "${expected_exit}" ]] || {
+    cat "${case_dir}/output" >&2
+    fail "${name} exited ${actual_exit}, expected ${expected_exit}"
+  }
+}
+
+run_case success
+assert_contains "${TEST_ROOT}/success/gcloud-calls" "compute instance-groups managed delete-instances test-mig"
+assert_contains "${TEST_ROOT}/success/gcloud-calls" "--project=test-project"
+assert_contains "${TEST_ROOT}/success/gcloud-calls" "--region=us-central1"
+assert_contains "${TEST_ROOT}/success/gcloud-calls" "--instances=test-agent-abcd"
+assert_contains "${TEST_ROOT}/success/gcloud-calls" "--skip-instances-on-validation-error"
+assert_contains "${TEST_ROOT}/success/gcloud-calls" "--quiet"
+assert_contains "${TEST_ROOT}/success/gcloud-calls" "--format=value(status)"
+assert_not_contains "${TEST_ROOT}/success/gcloud-calls" "compute instances delete"
+assert_contains "${TEST_ROOT}/success/timeout-calls" "--kill-after=5s 30s gcloud"
+assert_contains "${TEST_ROOT}/success/logger-calls" "Requesting removal of test-agent-abcd from regional managed instance group test-mig"
+assert_contains "${TEST_ROOT}/success/output" "GCP accepted deletion of test-agent-abcd from test-mig"
+
+GCLOUD_STATUSES=SKIPPED run_case already-deleting
+assert_contains "${TEST_ROOT}/already-deleting/output" "already absent or being removed"
+
+GCLOUD_STATUSES=MEMBER_NOT_FOUND run_case already-absent
+assert_contains "${TEST_ROOT}/already-absent/output" "MEMBER_NOT_FOUND"
+
+MAX_ATTEMPTS=2 GCLOUD_EMPTY_STATUS=true run_case empty-status 1
+assert_line_count "${TEST_ROOT}/empty-status/gcloud-calls" 2
+assert_contains "${TEST_ROOT}/empty-status/output" "GCP returned no deletion status"
+
+GCLOUD_STATUSES=FAIL,FAIL,SUCCESS run_case transient-status
+assert_line_count "${TEST_ROOT}/transient-status/gcloud-calls" 3
+grep -Fxq "2" "${TEST_ROOT}/transient-status/sleep-calls" || fail "first retry delay was not 2 seconds"
+grep -Fxq "4" "${TEST_ROOT}/transient-status/sleep-calls" || fail "second retry delay was not 4 seconds"
+
+GCLOUD_STATUSES=SUCCESS,SUCCESS GCLOUD_EXIT_CODES=1,0 run_case transient-command-failure
+assert_line_count "${TEST_ROOT}/transient-command-failure/gcloud-calls" 2
+
+MAX_ATTEMPTS=3 GCLOUD_STATUSES=FAIL run_case retry-exhaustion 1
+assert_line_count "${TEST_ROOT}/retry-exhaustion/gcloud-calls" 3
+assert_contains "${TEST_ROOT}/retry-exhaustion/output" "Unable to delete instance after 3 attempts"
+
+METADATA_FAILURE_CALLS=1 run_case transient-metadata
+assert_line_count "${TEST_ROOT}/transient-metadata/gcloud-calls" 1
+assert_contains "${TEST_ROOT}/transient-metadata/output" "Unable to read instance metadata (attempt 1/4)"
+
+MAX_ATTEMPTS=2 METADATA_FAILURE_CALLS=20 run_case metadata-exhaustion 1
+assert_line_count "${TEST_ROOT}/metadata-exhaustion/gcloud-calls" 0
+assert_contains "${TEST_ROOT}/metadata-exhaustion/output" "Unable to read instance identity after 2 attempts"
+
+METADATA_CREATED_BY=projects/123456789/zones/us-central1-a/instanceGroupManagers/test-mig run_case zonal-manager 1
+assert_line_count "${TEST_ROOT}/zonal-manager/gcloud-calls" 0
+assert_contains "${TEST_ROOT}/zonal-manager/output" "does not identify a regional managed instance group"
+
+METADATA_CREATED_BY=invalid run_case malformed-manager 1
+assert_line_count "${TEST_ROOT}/malformed-manager/gcloud-calls" 0
+assert_contains "${TEST_ROOT}/malformed-manager/output" "does not identify a regional managed instance group"
+
+MAX_ATTEMPTS=0 run_case invalid-attempt-count 1
+assert_line_count "${TEST_ROOT}/invalid-attempt-count/curl-calls" 0
+assert_contains "${TEST_ROOT}/invalid-attempt-count/output" "MAX_ATTEMPTS must be a positive integer"
+
+echo "PASS: terminate-instance"


### PR DESCRIPTION
This change implements an instance-removal process that allows an instance to shut down and remove itself from the instance group once its Buildkite agent has been idle for a set amount of time. This is safer than the existing scale-in mechanism, which doesn't know which instance is idle and so can terminate one that is running a job.

I've refactored the `terminate-instance` script so that it:

- Reads the current project ID, instance name, and `created-by` value from GCP metadata.
- Validates that the instance belongs to a regional managed instance group.
- Extracts the exact region and MIG name from the metadata.
- Removes the current VM with `gcloud compute instance-groups managed delete-instances`.
- Uses the local instance name to ensure that only the VM running the script is selected.
- Uses `--skip-instances-on-validation-error` and treats `SKIPPED` and `MEMBER_NOT_FOUND` as idempotent success states.
- Retries transient metadata and GCP failures with bounded exponential backoff.
- Applies a timeout to each gcloud request.
- Exits with an error rather than deleting the VM directly when it cannot remove the instance through the MIG.

The PR also adds testing and updates the CI pipeline accordingly. For right now, this script isn't actually invoked by anything. I'll have a follow-up PR to wire it in. 

Context: SUP-7630